### PR TITLE
added ignores for intellij, eclipse, maven and osx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Maven
+target/
+
+# IDEA
+.idea/
+*.iml
+
+# Eclipse
+.classpath
+.project
+.settings/
+
+# Mac OS X
+.DS_Store


### PR DESCRIPTION
To not commit settings for Eclipse or IntelliJ IDEA, compilation directory from Maven or trashed files on Mac OSX by accident I added a .gitignore file.
